### PR TITLE
[Fix] Only release on tagged commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,16 @@ workflows:
     jobs:
       - build:
           filters:
+            tags:
+              only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/
 
       - deployment:
           requires:
             - build
           filters:
+              tags:
+                only: /^v.*/
               branches:
-                only: master
+                ignore: /.*/


### PR DESCRIPTION
Wouldn't work great with dependabot with the master releases.